### PR TITLE
Added support for extra GET parameters

### DIFF
--- a/bootstrap-pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap-pagination/templatetags/bootstrap_pagination.py
@@ -1,4 +1,4 @@
-import re 
+import re
 
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.template import Context, Node, Library
@@ -7,6 +7,7 @@ from django.template import FilterExpression
 from django.template.defaultfilters import stringfilter
 from django.utils.encoding import force_unicode
 from django.conf import settings
+from django.http import QueryDict
 
 register = Library()
 
@@ -16,12 +17,12 @@ def strToBool(val):
     boolean True.
     """
     return val.lower() == "true"
-      
-def get_page_url(page_num, current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name):        
+
+def get_page_url(page_num, current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params):
     if url_view_name is not None:
-        # Add page param to the kwargs list. Overrides any previously set parameter of the same name.              
+        # Add page param to the kwargs list. Overrides any previously set parameter of the same name.
         url_extra_kwargs[url_param_name] = page_num
-        
+
        # This bit of code comes from the default django url tag
         try:
             url = reverse(url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)
@@ -31,18 +32,23 @@ def get_page_url(page_num, current_app, url_view_name, url_extra_args, url_extra
                 url = reverse(project_name + '.' + url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)
             else:
                 raise e
+
     else:
-           url = "?%s=%u" % (url_param_name, page_num)
-    
+        url = ''
+        url_get_params = url_get_params or QueryDict(url)
+        url_get_params = url_get_params.copy()
+        url_get_params[url_param_name] = page_num
+
+    url += '?' + url_get_params.urlencode()
     return url
-      
+
 @register.filter()
 @stringfilter
-def cat(value, arg): 
-     """ 
-     Concatenates value with argument 
-     """ 
-     return u"%s%s" % (value, force_unicode(arg)) 
+def cat(value, arg):
+     """
+     Concatenates value with argument
+     """
+     return u"%s%s" % (value, force_unicode(arg))
 cat.is_safe = True
 
 @register.filter
@@ -56,42 +62,42 @@ class BootstrapPagerNode(Node):
     def __init__(self, page, kwargs):
         self.page = page
         self.kwargs = kwargs
-        
+
     def render(self, context):
         page = self.page.resolve(context)
-        kwargs = self.kwargs 
-        
-         # Retrieve variable instances from context where necessary        
+        kwargs = self.kwargs
+
+         # Retrieve variable instances from context where necessary
         for argname, argvalue in kwargs.items():
             if isinstance(argvalue, FilterExpression):
                 try:
-                    kwargs[argname] = argvalue.resolve(context)   
+                    kwargs[argname] = argvalue.resolve(context)
                 except template.VariableDoesNotExist:
                     kwargs[argname] = str(argvalue)
-                    
+
         centered = strToBool(kwargs.get("centered", "false"))
         previous_label = str(kwargs.get("previous_label", "Previous Page"))
         next_label = str(kwargs.get("next_label", "Next Page"))
         previous_title = str(kwargs.get("previous_title", "Previous Page"))
         next_title = str(kwargs.get("next_title", "Next Page"))
-        
+
         url_view_name = kwargs.get("url_view_name", None)
         if url_view_name is not None:
             url_view_name = str(url_view_name)
-       
-        url_param_name = str(kwargs.get("url_param_name", "page"))        
+
+        url_param_name = str(kwargs.get("url_param_name", "page"))
         url_extra_args = kwargs.get("url_extra_args", [])
         url_extra_kwargs = kwargs.get("url_extra_kwargs", {})
-        
+
         previous_page_url = None
         if page.has_previous():
             previous_page_url = get_page_url(page.previous_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
-        
+
         next_page_url = None
         if page.has_next():
             next_page_url = get_page_url(page.next_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
-        
-        
+
+
         return get_template("bootstrap-pagination/pager.html").render(
             Context({
                 'page': page,
@@ -113,48 +119,47 @@ class BootstrapPaginationNode(Node):
         self.kwargs = kwargs
 
     def render(self, context):
-        page = self.page.resolve(context)    
+        page = self.page.resolve(context)
         kwargs = self.kwargs
-        
-        # Retrieve variable instances from context where necessary        
+
+        # Retrieve variable instances from context where necessary
         for argname, argvalue in kwargs.items():
             if isinstance(argvalue, FilterExpression):
                 try:
-                    kwargs[argname] = argvalue.resolve(context)   
+                    kwargs[argname] = argvalue.resolve(context)
                 except template.VariableDoesNotExist:
                     kwargs[argname] = str(argvalue)
-        
+
         # Unpack our keyword arguments, substituting defaults where necessary
-        
+
         range_length = kwargs.get("range", None)
         if range_length is not None:
             range_length = int(range_length)
-            
+
         alignment = str(kwargs.get("alignment", "center")).lower()
         if alignment not in ["left", "center", "right"]:
             raise Exception("Optional argument \"alignment\" expecting one of \"left\", \"center\", or \"right\"")
-        
+
         show_prev_next = strToBool(kwargs.get("show_prev_next", "true"))
-        previous_label = str(kwargs.get("previous_label", "&larr;"))        
+        previous_label = str(kwargs.get("previous_label", "&larr;"))
         next_label = str(kwargs.get("next_label", "&rarr;"))
         show_first_last = strToBool(kwargs.get("show_first_last", "false"))
-        first_label = str(kwargs.get("first_label", "&laquo;"))        
+        first_label = str(kwargs.get("first_label", "&laquo;"))
         last_label = str(kwargs.get("last_label", "&raquo;"))
-        
+
         url_view_name = kwargs.get("url_view_name", None)
         if url_view_name is not None:
             url_view_name = str(url_view_name)
-       
-        url_param_name = str(kwargs.get("url_param_name", "page"))        
+
+        url_param_name = str(kwargs.get("url_param_name", "page"))
         url_extra_args = kwargs.get("url_extra_args", [])
         url_extra_kwargs = kwargs.get("url_extra_kwargs", {})
-        
-        
+        url_get_params = kwargs.get("url_get_params", context['request'].GET)
 
         # Generage our viewable page range
         page_count = page.paginator.num_pages
-        current_page = page.number        
-     
+        current_page = page.number
+
         if range_length is None:
             range_min = 1
             range_max = page_count
@@ -164,7 +169,7 @@ class BootstrapPaginationNode(Node):
             elif range_length > page_count:
                 range_length = page_count
 
-            range_length -= 1                            
+            range_length -= 1
             range_min = max(current_page - (range_length / 2), 1)
             range_max = min(current_page + (range_length / 2), page_count)
             range_diff = range_max - range_min
@@ -174,40 +179,40 @@ class BootstrapPaginationNode(Node):
                     range_min -= shift
                 else:
                     range_max += shift
-                
-            
-        page_range = range(range_min, range_max + 1)     
-        
-        # Generate our URLs (page range + special urls for first, previous, next, and last)        
-        page_urls = {}        
-        for curpage in page_range:
-            url = get_page_url(curpage, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
 
-            page_urls[curpage] = url            
-        
+
+        page_range = range(range_min, range_max + 1)
+
+        # Generate our URLs (page range + special urls for first, previous, next, and last)
+        page_urls = {}
+        for curpage in page_range:
+            url = get_page_url(curpage, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params)
+
+            page_urls[curpage] = url
+
         first_page_url = None
         if current_page > 1:
-            first_page_url = get_page_url(1, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
-            
+            first_page_url = get_page_url(1, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params)
+
         last_page_url = None
         if current_page < page_count:
-            last_page_url = get_page_url(page_count, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
-        
+            last_page_url = get_page_url(page_count, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params)
+
         previous_page_url = None
         if page.has_previous():
-            previous_page_url = get_page_url(page.previous_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
+            previous_page_url = get_page_url(page.previous_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params)
 
         next_page_url = None
         if page.has_next():
-            next_page_url = get_page_url(page.next_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name)
-   
+            next_page_url = get_page_url(page.next_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params)
+
 
         return get_template("bootstrap-pagination/pagination.html").render(
             Context({
                 'page': page,
                 'alignment': alignment,
                 'show_prev_next': show_prev_next,
-                'show_first_last': show_first_last,                
+                'show_first_last': show_first_last,
                 'previous_label': previous_label,
                 'next_label': next_label,
                 'first_label': first_label,
@@ -216,69 +221,73 @@ class BootstrapPaginationNode(Node):
                 'first_page_url': first_page_url,
                 'last_page_url': last_page_url,
                 'previous_page_url': previous_page_url,
-                'next_page_url': next_page_url   
+                'next_page_url': next_page_url
             }, autoescape=False))
-    
+
 @register.tag
 def bootstrap_paginate(parser, token):
     """
     Renders a Page object as a Twitter Bootstrap styled pagination bar.
     Compatible with Bootstrap 2.x only.
-    
-    Example::    
-    
+
+    Example::
+
         {% bootstrap_paginate page_obj range=10 alignment="left" %}
-        
-    
+
+
     Named Parameters::
-    
+
         range - The size of the pagination bar (ie, if set to 10 then, at most,
                 10 page numbers will display at any given time) Defaults to
                 None, which shows all pages.
-                
+
         alignment - Accepts "left", "center", and "right". Defaults to
                     "center"
-        
+
         show_prev_next - Accepts "true" or "false". Determines whether or not
                         to show the previous and next page links. Defaults to
                         "true"
-                        
-                    
+
+
         show_first_last - Accepts "true" or "false". Determines whether or not
                           to show the first and last page links. Defaults to
                           "false"
-                    
+
         previous_label - The text to display for the previous page link.
                          Defaults to "&larr;"
-        
-        next_label - The text to display for the next page link. Defaults to 
+
+        next_label - The text to display for the next page link. Defaults to
                      "&rarr;"
-        
+
         first_label - The text to display for the first page link. Defaults to
                       "&laquo;"
-        
+
         last_label - The text to display for the last page link. Defaults to
                      "&raquo;"
-        
+
         url_name - The named URL to use. Defaults to None. If None, then the
                    default template simply appends the url parameter as a
                    relative URL link, eg: <a href="?page=1">1</a>
-                   
+
         url_param_name - The name of the parameter to use in the URL. If
                          url_name is set to None, this string is used as the
                          parameter name in the relative URL path. If a URL
-                         name is specified, this string is used as the 
+                         name is specified, this string is used as the
                          parameter name passed into the reverse() method for
                          the URL.
-                         
+
         url_extra_args - This is used only in conjunction with url_name.
                         When referencing a URL, additional arguments may be
                         passed in as a list.
-                        
+
         url_extra_kwargs - This is used only in conjunction with url_name.
                            When referencing a URL, additional named arguments
                            may be passed in as a dictionary.
-                                 
+
+        url_get_params - The other get parameters to pass, only the page
+                         number will be overwritten. Use this to preserve
+                         filters.
+
 
     """
     bits = token.split_contents()
@@ -288,7 +297,7 @@ def bootstrap_paginate(parser, token):
     page = parser.compile_filter(bits[1])
     kwargs = {}
     bits = bits[2:]
-    
+
     kwarg_re = re.compile(r'(\w+)=(.+)')
 
     if len(bits):
@@ -302,49 +311,53 @@ def bootstrap_paginate(parser, token):
 
     return BootstrapPaginationNode(page, kwargs)
 
-    
-    
+
+
 @register.tag
 def bootstrap_pager(parser, token):
     """
     Renders a Page object as a Twitter Bootstrap styled pager bar.
     Compatible with Bootstrap 2.x only.
-    
-    Example::    
-    
+
+    Example::
+
         {% bootstrap_pager page_obj alignment="left" %}
-        
-    
+
+
     Named Parameters::
-                
+
         centered - Accepts "true" or "false" (defaults to "false")
-        
+
         previous_label - The label to show for the Previous link (defaults to "Previous Page")
-        
+
         next_label - The label to show for the Next link (defualts to "Next Page")
-        
+
         previous_title - The link title for the previous link (defaults to "Previous Page")
-        
+
         next_title - The link title for the next link (defaults to "Next Page")
-        
+
         url_name - The named URL to use. Defaults to None. If None, then the
                    default template simply appends the url parameter as a
                    relative URL link, eg: <a href="?page=1">1</a>
-                   
+
         url_param_name - The name of the parameter to use in the URL. If
                          url_name is set to None, this string is used as the
                          parameter name in the relative URL path. If a URL
-                         name is specified, this string is used as the 
+                         name is specified, this string is used as the
                          parameter name passed into the reverse() method for
                          the URL.
-                         
+
         url_extra_args - This is used only in conjunction with url_name.
                         When referencing a URL, additional arguments may be
                         passed in as a list.
-                        
+
         url_extra_kwargs - This is used only in conjunction with url_name.
                            When referencing a URL, additional named arguments
                            may be passed in as a dictionary.
+
+        url_get_params - The other get parameters to pass, only the page
+                         number will be overwritten. Use this to preserve
+                         filters.
     """
     bits = token.split_contents()
     if len(bits) < 2:
@@ -353,7 +366,7 @@ def bootstrap_pager(parser, token):
     page = parser.compile_filter(bits[1])
     kwargs = {}
     bits = bits[2:]
-    
+
     kwarg_re = re.compile(r'(\w+)=(.+)')
 
     if len(bits):


### PR DESCRIPTION
When using GET parameters the pagination resets you to the main page every time.

This patch automatically uses request.GET to append extra query parameters. Alternatively you can pass a `QueryDict` with get parameters through the `url_get_params` parameter.
