### PR TITLE
Added pagination bar sizing options using an optional size argument

### DIFF
--- a/bootstrap-pagination/templates/bootstrap-pagination/pagination.html
+++ b/bootstrap-pagination/templates/bootstrap-pagination/pagination.html
@@ -1,5 +1,5 @@
 {% load bootstrap_pagination %}
-<div class="pagination {% if alignment == "center" %}pagination-centered{% endif %}{% if alignment == "right" %}pagination-right{% endif %} {% block extra_classes %}{% endblock %}">    
+<div class="pagination {% if size == "mini" %}pagination-mini{% endif %}{% if size == "small" %}pagination-small{% endif %}{% if size == "large" %}pagination-large{% endif %} {% if alignment == "center" %}pagination-centered{% endif %}{% if alignment == "right" %}pagination-right{% endif %} {% block extra_classes %}{% endblock %}">    
     <ul>    
     {% if show_first_last %}
          <li {% if not page.has_previous %}class="disabled"{% endif %}>         

--- a/bootstrap-pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap-pagination/templatetags/bootstrap_pagination.py
@@ -131,6 +131,12 @@ class BootstrapPaginationNode(Node):
         if alignment not in ["left", "center", "right"]:
             raise Exception("Optional argument \"alignment\" expecting one of \"left\", \"center\", or \"right\"")
 
+        size = kwargs.get("size", None)
+        if size is not None:
+            size = str(size.lower())
+            if size not in ["mini", "small", "large"]:
+                raise Exception("Optional argument \"size\" expecting one of \"mini\", \"small\", or \"large\"")
+
         show_prev_next = strToBool(kwargs.get("show_prev_next", "true"))
         previous_label = str(kwargs.get("previous_label", "&larr;"))
         next_label = str(kwargs.get("next_label", "&rarr;"))
@@ -199,6 +205,7 @@ class BootstrapPaginationNode(Node):
             Context({
                 'page': page,
                 'alignment': alignment,
+                'size': size,
                 'show_prev_next': show_prev_next,
                 'show_first_last': show_first_last,
                 'previous_label': previous_label,
@@ -232,6 +239,9 @@ def bootstrap_paginate(parser, token):
 
         alignment - Accepts "left", "center", and "right". Defaults to
                     "center"
+
+        size - Accepts "mini", "small", and "large". Defaults to
+                    None which is the standard size.
 
         show_prev_next - Accepts "true" or "false". Determines whether or not
                         to show the previous and next page links. Defaults to


### PR DESCRIPTION
This will add support for bootstrap pagination bar size. At the moment, the sizes supported are "mini", "small" and "large".

More details can be found on: http://twitter.github.com/bootstrap/components.html#pagination
