### PR TITLE
Removed mandatory project name into reverse

### DIFF
--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -31,7 +31,7 @@ def get_page_url(page_num, current_app, url_view_name, url_extra_args, url_extra
         except NoReverseMatch, e:
             if settings.SETTINGS_MODULE:
                 project_name = settings.SETTINGS_MODULE.split('.')[0]
-                url = reverse(project_name + '.' + url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)
+                url = reverse(url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)
             else:
                 raise e
 


### PR DESCRIPTION
Is there a valid reason for the project_name being mandatory on the reverse url ?

I'm currently using this in one of my projects and i need the possibility of specifying a full path for the reverse since i don't have my paginators on my main app. Shouldn't this be default behaviour ?

Regards
