### PR TITLE
python3 compatibility

### DIFF
--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -161,8 +161,8 @@ class BootstrapPaginationNode(Node):
                 range_length = page_count
 
             range_length -= 1
-            range_min = max(current_page - (range_length / 2), 1)
-            range_max = min(current_page + (range_length / 2), page_count)
+            range_min = max(current_page - (range_length // 2), 1)
+            range_max = min(current_page + (range_length // 2), page_count)
             range_diff = range_max - range_min
             if range_diff < range_length:
                 shift = range_length - range_diff

--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -28,7 +28,7 @@ def get_page_url(page_num, current_app, url_view_name, url_extra_args, url_extra
        # This bit of code comes from the default django url tag
         try:
             url = reverse(url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)
-        except NoReverseMatch, e:
+        except NoReverseMatch as e:
             if settings.SETTINGS_MODULE:
                 project_name = settings.SETTINGS_MODULE.split('.')[0]
                 url = reverse(project_name + '.' + url_view_name, args=url_extra_args, kwargs=url_extra_kwargs, current_app=current_app)

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-readme = open('README.rst', 'r')
-readme_text = readme.read()
-readme.close()
+
+with open('README.rst', 'rb') as readme:
+    readme_text = readme.read().decode('utf-8')
 
 setup(
     name='django-bootstrap-pagination',
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/jmcclell/django-bootstrap-pagination',
     license='MIT licence, see LICENCE',
     description='Render Django Page objects as Bootstrap 3.x Pagination compatible HTML',
-    long_description=readme_text.encode('UTF-8'),
+    long_description=readme_text,
     zip_safe=False,
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
this fixes the issue while installing for Python3:

```
$ pip install django-bootstrap-pagination
Downloading/unpacking django-bootstrap-pagination
  Downloading django-bootstrap-pagination-1.5.0.tar.gz
  Running setup.py (path:/Volumes/Data/Users/miki725/.virtualenvs/test-py3/build/django-bootstrap-pagination/setup.py) egg_info for package django-bootstrap-pagination
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/Volumes/Data/Users/miki725/.virtualenvs/test-py3/build/django-bootstrap-pagination/setup.py", line 26, in <module>
        "License :: OSI Approved :: MIT License",
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "<string>", line 14, in replacement_run
      File "/Volumes/Data/Users/miki725/.virtualenvs/test-py3/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 322, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 1108, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 1129, in write_pkg_file
        long_desc = rfc822_escape(self.get_long_description())
      File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/util.py", line 470, in rfc822_escape
        lines = header.split('\n')
    TypeError: Type str doesn't support the buffer API
    Complete output from command python setup.py egg_info:
    running egg_info

creating pip-egg-info/django_bootstrap_pagination.egg-info

writing dependency_links to pip-egg-info/django_bootstrap_pagination.egg-info/dependency_links.txt

writing pip-egg-info/django_bootstrap_pagination.egg-info/PKG-INFO

Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/Volumes/Data/Users/miki725/.virtualenvs/test-py3/build/django-bootstrap-pagination/setup.py", line 26, in <module>

    "License :: OSI Approved :: MIT License",

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/core.py", line 148, in setup

    dist.run_commands()

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 955, in run_commands

    self.run_command(cmd)

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command

    cmd_obj.run()

  File "<string>", line 14, in replacement_run

  File "/Volumes/Data/Users/miki725/.virtualenvs/test-py3/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 322, in write_pkg_info

    metadata.write_pkg_info(cmd.egg_info)

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 1108, in write_pkg_info

    self.write_pkg_file(pkg_info)

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 1129, in write_pkg_file

    long_desc = rfc822_escape(self.get_long_description())

  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/util.py", line 470, in rfc822_escape

    lines = header.split('\n')

TypeError: Type str doesn't support the buffer API

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /Volumes/Data/Users/miki725/.virtualenvs/test-py3/build/django-bootstrap-pagination
Storing debug log for failure in /Volumes/Data/Users/miki725/.pip/pip.log
```