### PR TITLE
show_index_range option

### DIFF
--- a/bootstrap_pagination/templates/bootstrap_pagination/pagination.html
+++ b/bootstrap_pagination/templates/bootstrap_pagination/pagination.html
@@ -10,14 +10,14 @@
         <a title="Previous Page" href="{{ previous_page_url|default:"#" }}">{{ previous_label }}</a>
     </li>
 {% endif %}
-{% for pagenum, url in page_urls %}
+{% for pagenum, index_range, url in page_urls %}
     {% if page.number == pagenum %}
         <li class="active">
-            <a title="Current Page" href="#">{{ pagenum }}</a>
+            <a title="Current Page" href="#">{% if show_index_range %} {{ index_range }} {% else %} {{ pagenum }} {%endif %}</a>
         </li>
     {% else %}
         <li>
-            <a title="Page {{ pagenum }} of {{ page.paginator.num_pages }}" href="{{ url }}">{{ pagenum }}</a>
+            <a title="Page {{ pagenum }} of {{ page.paginator.num_pages }}" href="{{ url }}">{% if show_index_range %} {{ index_range }} {% else %} {{ pagenum }} {%endif %}</a>
         </li>
     {% endif %}
 {% endfor %}

--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -141,6 +141,7 @@ class BootstrapPaginationNode(Node):
         show_first_last = strToBool(kwargs.get("show_first_last", "false"))
         first_label = str(kwargs.get("first_label", "&laquo;"))
         last_label = str(kwargs.get("last_label", "&raquo;"))
+        show_index_range = strToBool(kwargs.get("show_index_range", "false"))
 
         url_view_name = kwargs.get("url_view_name", None)
         if url_view_name is not None:
@@ -181,8 +182,13 @@ class BootstrapPaginationNode(Node):
         # Generate our URLs (page range + special urls for first, previous, next, and last)
         page_urls = []
         for curpage in page_range:
+            if curpage == page.paginator.num_pages:
+                index_range = "%s-%s" % (1 + (curpage - 1) * page.paginator.per_page, len(page.paginator.object_list), )
+            else:
+                index_range = "%s-%s" % (1 + (curpage - 1) * page.paginator.per_page, curpage * page.paginator.per_page, )
+                
             url = get_page_url(curpage, context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
-            page_urls.append((curpage, url))
+            page_urls.append((curpage, index_range, url))
 
         first_page_url = None
         if current_page >= 1:
@@ -204,6 +210,7 @@ class BootstrapPaginationNode(Node):
             Context({
                 'page': page,
                 'size': size,
+                'show_index_range': show_index_range,
                 'show_prev_next': show_prev_next,
                 'show_first_last': show_first_last,
                 'previous_label': previous_label,


### PR DESCRIPTION
Hi,
The paginator by default displays the page numbers:
[1, 2, __3__, 4, 5, etc.]

If I have 50 items per page, I have a need to display instead:
[1-50, 51-100, __101-150__, 151-200, 201-250, etc.].

The index_range is determined for each page and included in page_urls. I've added the parameter 'show_index_range' defaulting to 'false'. If true, the index_range is displayed by the template instead of pagenum.

I've retained the pagenum test in the template to ensure the active class is correctly applied.