### PR TITLE
Compatibility with Django 1.10

### DIFF
--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -5,6 +5,7 @@ from django.template import Context, Node, Library, TemplateSyntaxError, Variabl
 from django.template.loader import get_template
 from django.conf import settings
 from django.http import QueryDict
+from django.utils.html import mark_safe
 
 register = Library()
 
@@ -68,10 +69,10 @@ class BootstrapPagerNode(Node):
             except VariableDoesNotExist:
                 kwargs[argname] = None
 
-        previous_label = str(kwargs.get("previous_label", "Previous Page"))
-        next_label = str(kwargs.get("next_label", "Next Page"))
-        previous_title = str(kwargs.get("previous_title", "Previous Page"))
-        next_title = str(kwargs.get("next_title", "Next Page"))
+        previous_label = mark_safe(kwargs.get("previous_label", "Previous Page"))
+        next_label = mark_safe(kwargs.get("next_label", "Next Page"))
+        previous_title = mark_safe(kwargs.get("previous_title", "Previous Page"))
+        next_title = mark_safe(kwargs.get("next_title", "Next Page"))
 
         url_view_name = kwargs.get("url_view_name", None)
         if url_view_name is not None:
@@ -92,7 +93,7 @@ class BootstrapPagerNode(Node):
             next_page_url = get_page_url(page.next_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
 
         return get_template("bootstrap_pagination/pager.html").render(
-            Context({
+            {
                 'page': page,
                 'previous_label': previous_label,
                 'next_label': next_label,
@@ -100,7 +101,7 @@ class BootstrapPagerNode(Node):
                 'next_title': next_title,
                 'previous_page_url': previous_page_url,
                 'next_page_url': next_page_url
-            }, autoescape=False))
+            })
 
 
 class BootstrapPaginationNode(Node):
@@ -136,11 +137,11 @@ class BootstrapPaginationNode(Node):
                 raise Exception("Optional argument \"size\" expecting one of \"small\", or \"large\"")
 
         show_prev_next = strToBool(kwargs.get("show_prev_next", "true"))
-        previous_label = str(kwargs.get("previous_label", "&larr;"))
-        next_label = str(kwargs.get("next_label", "&rarr;"))
+        previous_label = mark_safe(kwargs.get("previous_label", "&larr;"))
+        next_label = mark_safe(kwargs.get("next_label", "&rarr;"))
         show_first_last = strToBool(kwargs.get("show_first_last", "false"))
-        first_label = str(kwargs.get("first_label", "&laquo;"))
-        last_label = str(kwargs.get("last_label", "&raquo;"))
+        first_label = mark_safe(kwargs.get("first_label", "&laquo;"))
+        last_label = mark_safe(kwargs.get("last_label", "&raquo;"))
         show_index_range = strToBool(kwargs.get("show_index_range", "false"))
 
         url_view_name = kwargs.get("url_view_name", None)
@@ -207,7 +208,7 @@ class BootstrapPaginationNode(Node):
             next_page_url = get_page_url(page.next_page_number(), context.current_app, url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
 
         return get_template("bootstrap_pagination/pagination.html").render(
-            Context({
+            {
                 'page': page,
                 'size': size,
                 'show_index_range': show_index_range,
@@ -222,7 +223,7 @@ class BootstrapPaginationNode(Node):
                 'last_page_url': last_page_url,
                 'previous_page_url': previous_page_url,
                 'next_page_url': next_page_url
-            }, autoescape=False))
+            })
 
 
 @register.tag


### PR DESCRIPTION
Pass template.render() a dict instead of a context. The context was used to pass the `autoencoder` parameter. This behaviour is now applied by marking the labels as safe html, causing them to render unencoded.

This adresses #44 