### PR TITLE
Fixed disabled previous link class.

### DIFF
--- a/bootstrap_pagination/templates/bootstrap_pagination/pager.html
+++ b/bootstrap_pagination/templates/bootstrap_pagination/pager.html
@@ -1,12 +1,12 @@
-<ul class="pager">     
-      {% if page.has_previous %}     
+<ul class="pager">
+      {% if page.has_previous %}
       <li{% if not centered %} class="previous"{% endif %}>
           <a title="{{ previous_title }}" href="{{ previous_page_url|default:"#"|escape }}">{{ previous_label }}</a>
-      </li>          
+      </li>
       {% else %}
-      <li class="{% if not centered %} next{% endif %} disabled">
+      <li class="{% if not centered %}previous{% endif %} disabled">
          <span title="{{ previous_title }}">{{ previous_label }}</span>
-      </li>      
+      </li>
       {% endif %}
 
       {% if page.has_next %}
@@ -16,6 +16,6 @@
       {% else %}
       <li title="{{ next_title }}" class="{% if not centered %} next{% endif %} disabled">
          <span>{{ next_label }}</span>
-      </li>      
+      </li>
       {% endif %}
-  </ul>         
+</ul>


### PR DESCRIPTION
In bootstrap_pager tag when there's no previous page, previous link is erroneously assigned `next` class causing the pager to render incorrectly.

Please, include the fix into the new release. I find keeping all the forks of open source projects and including them into `sources.txt` very inconvenient, but most maintainers ignore bugfixes or merge them but never upload new releases to PyPI.