### PR TITLE
Fix Django 1.10 warning

### DIFF
--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -122,7 +122,7 @@ class BootstrapPagerNode(Node):
             next_page_url = get_page_url(page.next_page_number(), get_current_app(context), url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
 
         return get_template("bootstrap_pagination/pager.html").render(
-            Context({
+            {
                 'page': page,
                 'previous_label': previous_label,
                 'next_label': next_label,
@@ -130,7 +130,7 @@ class BootstrapPagerNode(Node):
                 'next_title': next_title,
                 'previous_page_url': previous_page_url,
                 'next_page_url': next_page_url
-            }))
+            })
 
 
 class BootstrapPaginationNode(Node):
@@ -239,7 +239,7 @@ class BootstrapPaginationNode(Node):
             next_page_url = get_page_url(page.next_page_number(), get_current_app(context), url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
 
         return get_template("bootstrap_pagination/pagination.html").render(
-            Context({
+            {
                 'page': page,
                 'size': size,
                 'show_index_range': show_index_range,
@@ -254,7 +254,7 @@ class BootstrapPaginationNode(Node):
                 'last_page_url': last_page_url,
                 'previous_page_url': previous_page_url,
                 'next_page_url': next_page_url
-            }))
+            })
 
 
 @register.tag


### PR DESCRIPTION
 RemovedInDjango110Warning: render() must be called with a dict, not a Context.