### PR TITLE
Hide navigation controls from printable representation

### DIFF
--- a/bootstrap_pagination/templates/bootstrap_pagination/pager.html
+++ b/bootstrap_pagination/templates/bootstrap_pagination/pager.html
@@ -1,4 +1,4 @@
-<ul class="pager">
+<ul class="pager hidden-print">
       {% if page.has_previous %}
       <li{% if not centered %} class="previous"{% endif %}>
           <a title="{{ previous_title }}" href="{{ previous_page_url|default:"#"|escape }}">{{ previous_label }}</a>

--- a/bootstrap_pagination/templates/bootstrap_pagination/pagination.html
+++ b/bootstrap_pagination/templates/bootstrap_pagination/pagination.html
@@ -1,5 +1,5 @@
 {% load bootstrap_pagination %}
-<ul class="pagination{% if size == "small" %} pagination-sm{% endif %}{% if size == "large" %} pagination-lg{% endif %}{% block extra_classes %}{% endblock %}">
+<ul class="pagination{% if size == "small" %} pagination-sm{% endif %}{% if size == "large" %} pagination-lg{% endif %} hidden-print{% block extra_classes %}{% endblock %}">
 {% if show_first_last %}
     {% if not page.has_previous %}
       <li class="disabled">


### PR DESCRIPTION
Bootstrap pagination controls look really ugly on printed pages, and they make no sense anyway. I think it is better to hide them on printed pages.