### PR TITLE
Add Django 2 support

### DIFF
--- a/bootstrap_pagination/templatetags/bootstrap_pagination.py
+++ b/bootstrap_pagination/templatetags/bootstrap_pagination.py
@@ -1,7 +1,7 @@
 import re
 
 import django
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.template import Node, Library, TemplateSyntaxError, VariableDoesNotExist
 from django.template.loader import get_template
 from django.conf import settings
@@ -9,8 +9,8 @@ from django.http import QueryDict
 from django.utils.html import mark_safe
 
 
-# As of django 1.10, template rendering no longer accepts a context, but 
-# instead accepts only accepts a dict. Up until django 1.8, a context was 
+# As of django 1.10, template rendering no longer accepts a context, but
+# instead accepts only accepts a dict. Up until django 1.8, a context was
 # actually required. Fortunately Context takes a single dict parameter,
 # so for django >=1.9 we can get away with just passing a unit function.
 if django.VERSION < (1, 9, 0):
@@ -225,7 +225,7 @@ class BootstrapPaginationNode(Node):
                 index_range = "%s-%s" % (1 + (curpage - 1) * page.paginator.per_page, len(page.paginator.object_list), )
             else:
                 index_range = "%s-%s" % (1 + (curpage - 1) * page.paginator.per_page, curpage * page.paginator.per_page, )
-                
+
             url = get_page_url(curpage, get_current_app(context), url_view_name, url_extra_args, url_extra_kwargs, url_param_name, url_get_params, url_anchor)
             page_urls.append((curpage, index_range, url))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,5 @@
 import django.conf
-import django.core.urlresolvers
+import django.urls
 import django.http
 
 import mock
@@ -41,7 +41,7 @@ class TestHelpers(unittest.TestCase):
                 'reverse')
     def test_get_page_url_view_sub(self, mock_reverse):
         mock_reverse.side_effect = [
-            django.core.urlresolvers.NoReverseMatch(),
+            django.urls.NoReverseMatch(),
             "/some_nice_url"
         ]
         url = bootstrap_pagination.get_page_url(


### PR DESCRIPTION
This pull requests adds support for Django 2.0. It will also support Django 1.11. It does not support lower versions of Django. That makes sense because Django versions less than Django 1.11 are no longer supported. Tests fail though because they are meant for lower versions of Django.